### PR TITLE
Algumas sugestões da tradução

### DIFF
--- a/translations/pt/translation.json
+++ b/translations/pt/translation.json
@@ -11,7 +11,7 @@
       "large": "Se o seu arquivo grande não for carregado com sucesso, nós recomendamos dividir o arquivo em segmentos menores e carregar esses.",
       "strings": "Ocorreu um problema ao carregar seu arquivo de texto. {{suggestion}}",
       "suggestion": "Verifique se o caminho do arquivo ({{filePath}}) está correto, tente hospedar o arquivo online ou em um servidor local.\n\n+ Para mais informações, visite: {{url}}",
-      "table": "Ocorreu um problema ao carregar seu arquivo de tabela. {{suggestion}}",
+      "table": "Ocorreu um problema ao carregar seu arquivo tabela. {{suggestion}}",
       "xml": "Ocorreu um problema ao carregar seu arquivo XML. {{suggestion}}"
     },
     "friendlyParamError": {
@@ -37,7 +37,7 @@
       "type": {
         "constAssign": "\n{{location}} Uma variável constante está sendo reatribuída. Em JavaScript, não é permitido atribuir um novo valor à uma constante. Se você que atribuir novos valores à uma variável, certifique-se de que ela é declarada como var ou let.\n\n+ Para mais informações, visite: {{url}}",
         "notfunc": "\n{{location}} Não foi possível chamar \"{{symbol}}\" como uma função.\nVerifique o seu tipo e o escopo e se a escrita e a caixa estão corretas (JavaScript diferencia maiúsculas de minúsculas).\n\n+ Para mais informações, visite: {{url}}",
-        "notfuncObj": "\n{{location}} Não foi possível chamar \"{{symbol}}\" como uma função.\nVerifique se \"{{obj}}\" contêm \"{{symbol}}\". Verifique o seu tipo e o escopo e se a escrita e a caixa estão corretas (JavaScript diferencia maiúsculas de minúsculas).\n\n+ Para mais informações, visite: {{url}}",
+        "notfuncObj": "\n{{location}} Não foi possível chamar \"{{symbol}}\" como uma função.\nVerifique se \"{{obj}}\" contém \"{{symbol}}\". Verifique o seu tipo e o escopo e se a escrita e a caixa estão corretas (JavaScript diferencia maiúsculas de minúsculas).\n\n+ Para mais informações, visite: {{url}}",
         "readFromNull": "\n{{location}} Não foi possível ler a propiedade de null. Em JavaScript o valor null indica que um objeto não tem valor.\n\n+ Para mais informações, visite: {{url}}",
         "readFromUndefined": "\n{{location}} Não foi possível ler a propiedade undefined. Verifique o número da linha na mensagem de erro e certifique-se de que a variável relevante foi definida.\n\n + Para mais informações, visite: {{url}}"
       }
@@ -63,10 +63,10 @@
     },
     "pre": "\n🌸 p5.js diz: {{message}}",
     "sketchReaderErrors": {
-      "reservedConst": "você usou uma variável reservada por p5.js \"{{symbol}}\" lembre-se de alterar o nome da variável.\n\n+ Para mais informações, visite: {{url}}",
-      "reservedFunc": "você usou uma função reservada por p5.js \"{{symbol}}\" lembre-se de alterar o nome da função.\n\n+ Para mais informações, visite: {{url}}"
+      "reservedConst": "Você usou uma variável reservada por p5.js \"{{symbol}}\" Lembre-se de por um outro nome para essa variável.\n\n+ Para mais informações, visite: {{url}}",
+      "reservedFunc": "Você usou uma função reservada por p5.js \"{{symbol}}\" Lembre-se de por um outro nome para essa função.\n\n+ Para mais informações, visite: {{url}}"
     },
-    "welcome": "Bem-vindo! Eu sou o seu amigo depurador. Para me desligar, mude para p5.min.js.",
+    "welcome": "Bem-vindo! Eu sou o seu amigo depurador. Para me desligar, use o p5.min.js.",
     "wrongPreload": "{{location}} Ocorreu um erro com a mensagem \"{{error}}\" dentro da biblioteca p5js quando \"{{func}}\" foi chamado. Se nada indica o contrário, pode ser devido à \"{{func}}\" ser chamado pelo preload. Nada além de funções load (loadImage, loadJSON, loadFont, loadStrings, etc.) devem estar dentro da função preload."
   }
 }


### PR DESCRIPTION
- "arquivo de tabela" para apenas "arquivo tabela", pois vc ñ usa a preposição "de" para os outros tipos de arquivo; além do que "de tabela" é tb uma expressão esportiva.
- Conjugação "contêm" para "contém", pois a versão com circunflexo é plural.
- "Alterar o nome" parece formal d+. "Por um outro nome para essa" parece-me + natural. Apenas uma sugestão, claro.
- Acho q "use o p5.min.js." passa uma compreensão melhor q "mude para p5.min.js.".